### PR TITLE
Allow bypassing of CA checks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	CacheDirectory string `json:"-"`
 	Debug          bool
 	Trace          bool
+	Insecure       bool
 	DockerEndpoint string
 }
 
@@ -44,6 +45,7 @@ func createDefaultConfig() error {
 	defaultConfig = &Config{
 		CacheDirectory: trivyCacheDir,
 		Debug:          false,
+		Insecure:       false,
 		Vulnerability: VulnerabilityConfig{
 			IgnoreUnfixed: false,
 		},

--- a/pkg/controllers/filesystem/fs.go
+++ b/pkg/controllers/filesystem/fs.go
@@ -18,7 +18,7 @@ type Controller struct {
 }
 
 func (c *Controller) SetWorkingDirectory(dir string) {
-	c.workingDireectory = dir
+	c.workingDirectory = dir
 	c.Config.Filesystem.WorkingDirectory = dir
 
 	if v, ok := c.Views[widgets.ScanPath]; ok {
@@ -40,7 +40,7 @@ func NewFilesystemController(cui *gocui.Gui, dockerClient *dockerClient.Client, 
 			Config:       cfg,
 		},
 		&state{
-			workingDireectory: cfg.Filesystem.WorkingDirectory,
+			workingDirectory: cfg.Filesystem.WorkingDirectory,
 		},
 	}
 }
@@ -53,7 +53,7 @@ func (c *Controller) CreateWidgets(manager base.Manager) error {
 	c.Views[widgets.Results] = widgets.NewFSResultWidget(widgets.Results, c)
 	c.Views[widgets.Menu] = widgets.NewMenuWidget(widgets.Menu, 0, maxY-3, maxX-1, maxY-1)
 	c.Views[widgets.Status] = widgets.NewStatusWidget(widgets.Status)
-	c.Views[widgets.ScanPath] = widgets.NewScanPathWidget(widgets.Host, c.workingDireectory, c)
+	c.Views[widgets.ScanPath] = widgets.NewScanPathWidget(widgets.Host, c.workingDirectory, c)
 
 	for _, v := range c.Views {
 		_ = v.Layout(c.Cui)

--- a/pkg/controllers/filesystem/local.go
+++ b/pkg/controllers/filesystem/local.go
@@ -65,7 +65,7 @@ func (c *Controller) scanVulnerabilities() error {
 		defer c.Unlock()
 		cancellable, c.ActiveCancel = context.WithCancel(context.Background())
 
-		report, err := c.DockerClient.ScanFilesystem(cancellable, c.workingDireectory, scanChecks, c)
+		report, err := c.DockerClient.ScanFilesystem(cancellable, c.workingDirectory, scanChecks, c)
 		if err != nil {
 			logger.Errorf("error scanning filesystem: %v", err)
 		}
@@ -129,7 +129,7 @@ func (c *Controller) showPathChange(gui *gocui.Gui, _ *gocui.View) error {
 	maxX, maxY := gui.Size()
 
 	gui.Cursor = true
-	pathChange, err := widgets.NewPathChangeWidget(widgets.PathChange, maxX, maxY, 150, c.workingDireectory, c)
+	pathChange, err := widgets.NewPathChangeWidget(widgets.PathChange, maxX, maxY, 150, c.workingDirectory, c)
 	if err != nil {
 		return fmt.Errorf("failed to create pathchange input: %w", err)
 	}

--- a/pkg/controllers/filesystem/local.go
+++ b/pkg/controllers/filesystem/local.go
@@ -65,7 +65,7 @@ func (c *Controller) scanVulnerabilities() error {
 		defer c.Unlock()
 		cancellable, c.ActiveCancel = context.WithCancel(context.Background())
 
-		report, err := c.DockerClient.ScanFilesystem(cancellable, c.workingDirectory, scanChecks, c)
+		report, err := c.DockerClient.ScanFilesystem(cancellable, c.workingDirectory, scanChecks, c.Config.Insecure, c)
 		if err != nil {
 			logger.Errorf("error scanning filesystem: %v", err)
 		}

--- a/pkg/controllers/filesystem/state.go
+++ b/pkg/controllers/filesystem/state.go
@@ -5,8 +5,8 @@ import (
 )
 
 type state struct {
-	workingDireectory string
-	currentTarget     string
-	currentReport     *output.Report
-	currentResult     *output.Result
+	workingDirectory string
+	currentTarget    string
+	currentReport    *output.Report
+	currentResult    *output.Result
 }

--- a/pkg/controllers/vulnerabilities/image.go
+++ b/pkg/controllers/vulnerabilities/image.go
@@ -26,7 +26,7 @@ func (c *Controller) ScanImage(ctx context.Context) {
 	defer c.Unlock()
 	cancellable, c.ActiveCancel = context.WithCancel(ctx)
 	go func() {
-		report, err := c.DockerClient.ScanImage(cancellable, c.selectedImage, c)
+		report, err := c.DockerClient.ScanImage(cancellable, c.selectedImage, c.Config.Insecure, c)
 		if err != nil {
 			return
 		}
@@ -90,7 +90,7 @@ func (c *Controller) ScanAllImages(gui *gocui.Gui, _ *gocui.View) error {
 	go func() {
 		var reports []*output.Report
 
-		err := c.DockerClient.ScanAllImages(cancellable, c, func(report *output.Report) error {
+		err := c.DockerClient.ScanAllImages(cancellable, c.Config.Insecure, c, func(report *output.Report) error {
 			reports = append(reports, report)
 			if err := c.RenderResultsReportSummary(reports); err != nil {
 				c.UpdateStatus(err.Error())

--- a/pkg/dockerClient/fs.go
+++ b/pkg/dockerClient/fs.go
@@ -8,10 +8,14 @@ import (
 	"github.com/owenrumney/lazytrivy/pkg/output"
 )
 
-func (c *Client) ScanFilesystem(ctx context.Context, path string, requiredChecks []string, progress Progress) (*output.Report, error) {
+func (c *Client) ScanFilesystem(ctx context.Context, path string, requiredChecks []string, insecure bool, progress Progress) (*output.Report, error) {
 	checks := strings.Join(requiredChecks, ",")
 	progress.UpdateStatus(fmt.Sprintf("Scanning filesystem %s...", path))
-	command := []string{"fs", "--quiet", "--security-checks", checks, "-f=json", "/target"}
+	command := []string{"fs", "--quiet"}
+	if insecure {
+		command = append(command, "--insecure")
+	}
+	command = append(command, "--security-checks", checks, "-f=json", "/target")
 
 	return c.scan(ctx, command, path, []string{}, progress, "lazytrivy:1.0.0", EngineDocker, fmt.Sprintf("%s:/target", path))
 }

--- a/pkg/dockerClient/images.go
+++ b/pkg/dockerClient/images.go
@@ -50,10 +50,10 @@ func (c *Client) ListImages() []string {
 	return c.imageNames
 }
 
-func (c *Client) ScanAllImages(ctx context.Context, progress Progress, reportComplete func(report *output.Report) error) error {
+func (c *Client) ScanAllImages(ctx context.Context, insecure bool, progress Progress, reportComplete func(report *output.Report) error) error {
 
 	for _, imageName := range c.imageNames {
-		report, err := c.ScanImage(ctx, imageName, progress)
+		report, err := c.ScanImage(ctx, imageName, insecure, progress)
 		if err != nil {
 			return err
 		}
@@ -72,9 +72,13 @@ func (c *Client) ScanAllImages(ctx context.Context, progress Progress, reportCom
 	return nil
 }
 
-func (c *Client) ScanImage(ctx context.Context, imageName string, progress Progress) (*output.Report, error) {
+func (c *Client) ScanImage(ctx context.Context, imageName string, insecure bool, progress Progress) (*output.Report, error) {
 	progress.UpdateStatus(fmt.Sprintf("Scanning image %s...", imageName))
-	command := []string{"image", "-f=json", imageName}
+	command := []string{"image", "-f=json"}
+	if insecure {
+		command = append(command, "--insecure")
+	}
+	command = append(command, imageName)
 
 	if report, err := c.scan(ctx, command, imageName, []string{}, progress, "aquasec/trivy:latest", EngineDocker); err == nil {
 		return report, nil

--- a/pkg/widgets/settings.go
+++ b/pkg/widgets/settings.go
@@ -33,6 +33,7 @@ func NewSettingsWidget(name string, x, y, w, h int, gui *gocui.Gui, cfg *config.
 func (w *SettingsWidget) Draw() {
 	w.form.AddHeading("General Options")
 	w.form.AddCheckBox("  Enable Debugging", 25, w.cfg.Debug)
+	w.form.AddCheckBox("  Disable CA Verification", 25, w.cfg.Insecure)
 	w.form.AddInputField("  Trivy Cache", 25, 30, w.cfg.CacheDirectory)
 	w.form.AddHeading("Scanning Options")
 	w.form.AddCheckBox("  Scan Vulnerabilities", 25, w.cfg.Filesystem.ScanVulnerabilities)
@@ -43,6 +44,7 @@ func (w *SettingsWidget) Draw() {
 	w.form.AddButton("Save", func(gui *gocui.Gui, view *gocui.View) error {
 
 		w.cfg.Debug = w.form.GetCheckBoxState("  Enable Debugging")
+		w.cfg.Insecure = w.form.GetCheckBoxState("  Disable CA Verification")
 		w.cfg.CacheDirectory = w.form.GetFieldText("  Trivy Cache")
 		w.cfg.Filesystem.ScanVulnerabilities = w.form.GetCheckBoxState("  Scan Vulnerabilities")
 		w.cfg.Filesystem.ScanMisconfiguration = w.form.GetCheckBoxState("  Scan Misconfigs")


### PR DESCRIPTION
HTTP proxies might use unknown root CAs. Trivy supports bypassing the CA
check. We are allowing this to be configured in lazytrivy now